### PR TITLE
Call close(fd) instead of shutdown to avoid fd leak

### DIFF
--- a/beanstalk.c
+++ b/beanstalk.c
@@ -72,7 +72,7 @@ int bs_connect(char *host, int port) {
 
     freeaddrinfo(addr);
     if (connect(fd, (struct sockaddr*)&server, sizeof(server)) != 0) {
-        shutdown(fd, SHUT_RDWR);
+        close(fd);
         return BS_STATUS_FAIL;
     }
 
@@ -80,7 +80,7 @@ int bs_connect(char *host, int port) {
 }
 
 int bs_disconnect(int fd) {
-    shutdown(fd, SHUT_RDWR);
+    close(fd);
     return BS_STATUS_OK;
 }
 


### PR DESCRIPTION
In the bs_connect method when a connection fails and in the bs_disconnect method, shutdown is used instead of close.  This results in an fd being leaked each time a process tries to use bs_disconnect.  Using close instead resolves this issue.
