### PR TITLE
Fix reading error for job sizes around 490 bytes

### DIFF
--- a/beanstalk.c
+++ b/beanstalk.c
@@ -218,7 +218,7 @@ BSM* bs_recv_message(int fd, int expect_data) {
     data = message->data + message->size;
 
     // already read the body along with status, all good.
-    if (expect_data_bytes < message->size) {
+    if ((expect_data_bytes + 2) <= message->size) {
         message->size = expect_data_bytes;
         return message;
     }

--- a/test/test2.cc
+++ b/test/test2.cc
@@ -78,6 +78,23 @@ TEST(JOB, MULTIPLE_LARGE_MESSAGES) {
     }
 }
 
+TEST(JOB, INITIAL_READ_BUFFER) {
+    Job job;
+    Client client("127.0.0.1", 11300);
+    ASSERT_TRUE(client.use("test"));
+    ASSERT_TRUE(client.watch("test"));
+
+    for (int i = 480; i < 500; i++) {
+      string message(i, 'x');
+
+      client.put(message);
+
+      ASSERT_TRUE(client.reserve(job));
+      ASSERT_TRUE(client.del(job.id()));
+    }
+    client.disconnect();
+}
+
 int main(int argc, char *argv[]) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
When the beanstalkd status is read into the initial buffer, the expected size
doesn't take \r\n after job data into account.
For jobs where status_size + job_data = 511 the \n will be left in the socket's
buffer. This breaks the next command because the \n is not expected when the
next beanstalk status is read.
