### PR TITLE
Add error codes for generic errors

### DIFF
--- a/beanstalk.c
+++ b/beanstalk.c
@@ -26,7 +26,11 @@ const char *bs_status_verbose[] = {
     "Not found",
     "Deadline soon",
     "Buried",
-    "Not ignored"
+    "Not ignored",
+    "Out of memory",
+    "Internal error",
+    "Bad format",
+    "Unknown command"
 };
 
 const char bs_resp_using[]          = "USING";
@@ -47,6 +51,10 @@ const char bs_resp_not_ignored[]    = "NOT_IGNORED";
 const char bs_resp_found[]          = "FOUND";
 const char bs_resp_kicked[]         = "KICKED";
 const char bs_resp_ok[]             = "OK";
+const char bs_resp_out_of_memory[]  = "OUT_OF_MEMORY";
+const char bs_resp_internal_error[] = "INTERNAL_ERROR";
+const char bs_resp_bad_format[]     = "BAD_FORMAT";
+const char bs_resp_unknown_command[]= "UNKNOWN_COMMAND";
 
 const char* bs_status_text(int code) {
     code = abs(code);
@@ -322,6 +330,10 @@ void bs_message_packet_free(BSMP *packet) {
 }
 
 #define BS_RETURN_INVALID(message) {                        \
+    BS_RETURN_FAIL_WHEN(message, bs_resp_out_of_memory, BS_STATUS_OUT_OF_MEMORY);     \
+    BS_RETURN_FAIL_WHEN(message, bs_resp_internal_error, BS_STATUS_INTERNAL_ERROR);   \
+    BS_RETURN_FAIL_WHEN(message, bs_resp_bad_format, BS_STATUS_BAD_FORMAT);           \
+    BS_RETURN_FAIL_WHEN(message, bs_resp_unknown_command, BS_STATUS_UNKNOWN_COMMAND); \
     bs_free_message(message);                               \
     return BS_STATUS_FAIL;                                  \
 }

--- a/beanstalk.h
+++ b/beanstalk.h
@@ -11,16 +11,20 @@
 #include <netinet/in.h>
 #include <sys/fcntl.h>
 
-#define BS_STATUS_OK             0
-#define BS_STATUS_FAIL          -1
-#define BS_STATUS_EXPECTED_CRLF -2
-#define BS_STATUS_JOB_TOO_BIG   -3
-#define BS_STATUS_DRAINING      -4
-#define BS_STATUS_TIMED_OUT     -5
-#define BS_STATUS_NOT_FOUND     -6
-#define BS_STATUS_DEADLINE_SOON -7
-#define BS_STATUS_BURIED        -8
-#define BS_STATUS_NOT_IGNORED   -9
+#define BS_STATUS_OK                0
+#define BS_STATUS_FAIL             -1
+#define BS_STATUS_EXPECTED_CRLF    -2
+#define BS_STATUS_JOB_TOO_BIG      -3
+#define BS_STATUS_DRAINING         -4
+#define BS_STATUS_TIMED_OUT        -5
+#define BS_STATUS_NOT_FOUND        -6
+#define BS_STATUS_DEADLINE_SOON    -7
+#define BS_STATUS_BURIED           -8
+#define BS_STATUS_NOT_IGNORED      -9
+#define BS_STATUS_OUT_OF_MEMORY   -10
+#define BS_STATUS_INTERNAL_ERROR  -11
+#define BS_STATUS_BAD_FORMAT      -12
+#define BS_STATUS_UNKNOWN_COMMAND -13
 
 #ifdef __cplusplus
     extern "C" {


### PR DESCRIPTION
This simply adds the generic errors defined in the beanstalk protocol and treats them in the client library so it'll return different error codes if one of these errors is encountered.
I think it would make sense to make these error codes available in the c++ client as well, although this would need major changes in the API, as the function only return bool now.
