### PR TITLE
Change ids to be int64_t and fix type conversion warnings

### DIFF
--- a/beanstalk.cc
+++ b/beanstalk.cc
@@ -11,7 +11,7 @@ namespace Beanstalk {
         _id = 0;
     }
 
-    Job::Job(int id, char *data, size_t size) {
+    Job::Job(int64_t id, char *data, size_t size) {
         _body.assign(data, size);
         _id = id;
     }
@@ -31,7 +31,7 @@ namespace Beanstalk {
         return _body;
     }
 
-    int Job::id() {
+    int64_t Job::id() {
         return _id;
     }
 
@@ -116,13 +116,13 @@ namespace Beanstalk {
         return bs_ignore(handle, (char*)tube.c_str()) == BS_STATUS_OK;
     }
 
-    int Client::put(string body, int priority, int delay, int ttr) {
-        int id = bs_put(handle, priority, delay, ttr, (char*)body.data(), body.size());
+    int64_t Client::put(string body, uint32_t priority, uint32_t delay, uint32_t ttr) {
+        int64_t id = bs_put(handle, priority, delay, ttr, (char*)body.data(), body.size());
         return (id > 0 ? id : 0);
     }
 
-    int Client::put(char *body, size_t bytes, int priority, int delay, int ttr) {
-        int id = bs_put(handle, priority, delay, ttr, body, bytes);
+    int64_t Client::put(char *body, size_t bytes, uint32_t priority, uint32_t delay, uint32_t ttr) {
+        int64_t id = bs_put(handle, priority, delay, ttr, body, bytes);
         return (id > 0 ? id : 0);
     }
 
@@ -130,7 +130,7 @@ namespace Beanstalk {
         return bs_delete(handle, job.id()) == BS_STATUS_OK;
     }
 
-    bool Client::del(int id) {
+    bool Client::del(int64_t id) {
         return bs_delete(handle, id) == BS_STATUS_OK;
     }
 
@@ -143,7 +143,7 @@ namespace Beanstalk {
         return false;
     }
 
-    bool Client::reserve(Job &job, int timeout) {
+    bool Client::reserve(Job &job, uint32_t timeout) {
         BSJ *bsj;
         if (bs_reserve_with_timeout(handle, timeout, &bsj) == BS_STATUS_OK) {
             job = bsj;
@@ -152,19 +152,19 @@ namespace Beanstalk {
         return false;
     }
 
-    bool Client::release(Job &job, int priority, int delay) {
+    bool Client::release(Job &job, uint32_t priority, uint32_t delay) {
         return bs_release(handle, job.id(), priority, delay) == BS_STATUS_OK;
     }
 
-    bool Client::release(int id, int priority, int delay) {
+    bool Client::release(int64_t id, uint32_t priority, uint32_t delay) {
         return bs_release(handle, id, priority, delay) == BS_STATUS_OK;
     }
 
-    bool Client::bury(Job &job, int priority) {
+    bool Client::bury(Job &job, uint32_t priority) {
         return bs_bury(handle, job.id(), priority) == BS_STATUS_OK;
     }
 
-    bool Client::bury(int id, int priority) {
+    bool Client::bury(int64_t id, uint32_t priority) {
         return bs_bury(handle, id, priority) == BS_STATUS_OK;
     }
 
@@ -172,11 +172,11 @@ namespace Beanstalk {
         return bs_touch(handle, job.id()) == BS_STATUS_OK;
     }
 
-    bool Client::touch(int id) {
+    bool Client::touch(int64_t id) {
         return bs_touch(handle, id) == BS_STATUS_OK;
     }
 
-    bool Client::peek(Job &job, int id) {
+    bool Client::peek(Job &job, int64_t id) {
         BSJ *bsj;
         if (bs_peek(handle, id, &bsj) == BS_STATUS_OK) {
             job = bsj;
@@ -267,7 +267,7 @@ namespace Beanstalk {
         return stats;
     }
 
-    info_hash_t Client::stats_job(int id) {
+    info_hash_t Client::stats_job(int64_t id) {
         char *yaml, *data;
         info_hash_t stats;
         string key, value;

--- a/beanstalk.h
+++ b/beanstalk.h
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -33,7 +34,7 @@ typedef struct bs_message {
 } BSM;
 
 typedef struct bs_job {
-    int id;
+    int64_t id;
     char *data;
     size_t size;
 } BSJ;
@@ -76,20 +77,20 @@ BSC_EXPORT int bs_connect(char *host, int port);
 BSC_EXPORT int bs_connect_with_timeout(char *host, int port, float secs);
 
 // returns job id or one of the negative failure codes.
-BSC_EXPORT int bs_put(int fd, int priority, int delay, int ttr, char *data, size_t bytes);
+BSC_EXPORT int64_t bs_put(int fd, uint32_t priority, uint32_t delay, uint32_t ttr, char *data, size_t bytes);
 
 // rest return BS_STATUS_OK or one of the failure codes.
 BSC_EXPORT int bs_disconnect(int fd);
 BSC_EXPORT int bs_use(int fd, char *tube);
 BSC_EXPORT int bs_watch(int fd, char *tube);
 BSC_EXPORT int bs_ignore(int fd, char *tube);
-BSC_EXPORT int bs_delete(int fd, int job);
+BSC_EXPORT int bs_delete(int fd, int64_t job);
 BSC_EXPORT int bs_reserve(int fd, BSJ **job);
-BSC_EXPORT int bs_reserve_with_timeout(int fd, int ttl, BSJ **job);
-BSC_EXPORT int bs_release(int fd, int id, int priority, int delay);
-BSC_EXPORT int bs_bury(int fd, int id, int priority);
-BSC_EXPORT int bs_touch(int fd, int id);
-BSC_EXPORT int bs_peek(int fd, int id, BSJ **job);
+BSC_EXPORT int bs_reserve_with_timeout(int fd, uint32_t ttl, BSJ **job);
+BSC_EXPORT int bs_release(int fd, int64_t id, uint32_t priority, uint32_t delay);
+BSC_EXPORT int bs_bury(int fd, int64_t id, uint32_t priority);
+BSC_EXPORT int bs_touch(int fd, int64_t id);
+BSC_EXPORT int bs_peek(int fd, int64_t id, BSJ **job);
 BSC_EXPORT int bs_peek_ready(int fd, BSJ **job);
 BSC_EXPORT int bs_peek_delayed(int fd, BSJ **job);
 BSC_EXPORT int bs_peek_buried(int fd, BSJ **job);
@@ -98,7 +99,7 @@ BSC_EXPORT int bs_list_tube_used(int fd, char **tube);
 BSC_EXPORT int bs_list_tubes(int fd, char **yaml);
 BSC_EXPORT int bs_list_tubes_watched(int fd, char **yaml);
 BSC_EXPORT int bs_stats(int fd, char **yaml);
-BSC_EXPORT int bs_stats_job(int fd, int id, char **yaml);
+BSC_EXPORT int bs_stats_job(int fd, int64_t id, char **yaml);
 BSC_EXPORT int bs_stats_tube(int fd, char *tube, char **yaml);
 
 #ifdef __cplusplus

--- a/beanstalk.hpp
+++ b/beanstalk.hpp
@@ -11,14 +11,14 @@ namespace Beanstalk {
 
     class Job {
         public:
-            int id();
+            int64_t id();
             std::string& body();
-            Job(int, char*, size_t);
+            Job(int64_t, char*, size_t);
             Job(BSJ*);
             Job();
             operator bool() { return _id > 0; }
         protected:
-            int _id;
+            int64_t _id;
             std::string _body;
     };
 
@@ -31,19 +31,19 @@ namespace Beanstalk {
             bool use(std::string);
             bool watch(std::string);
             bool ignore(std::string);
-            int  put(std::string, int priority = 0, int delay = 0, int ttr = 60);
-            int  put(char *data, size_t bytes, int priority, int delay, int ttr);
-            bool del(int id);
+            int64_t put(std::string, uint32_t priority = 0, uint32_t delay = 0, uint32_t ttr = 60);
+            int64_t put(char *data, size_t bytes, uint32_t priority, uint32_t delay, uint32_t ttr);
+            bool del(int64_t id);
             bool del(Job&);
             bool reserve(Job &);
-            bool reserve(Job &, int timeout);
-            bool release(Job &, int priority = 1, int delay = 0);
-            bool release(int id, int priority = 1, int delay = 0);
-            bool bury(Job &, int priority = 1);
-            bool bury(int id, int priority = 1);
+            bool reserve(Job &, uint32_t timeout);
+            bool release(Job &, uint32_t priority = 1, uint32_t delay = 0);
+            bool release(int64_t id, uint32_t priority = 1, uint32_t delay = 0);
+            bool bury(Job &, uint32_t priority = 1);
+            bool bury(int64_t id, uint32_t priority = 1);
             bool touch(Job &);
-            bool touch(int id);
-            bool peek(Job &, int id);
+            bool touch(int64_t id);
+            bool peek(Job &, int64_t id);
             bool peek_ready(Job &);
             bool peek_delayed(Job &);
             bool peek_buried(Job &);
@@ -55,7 +55,7 @@ namespace Beanstalk {
             info_list_t list_tubes();
             info_list_t list_tubes_watched();
             info_hash_t stats();
-            info_hash_t stats_job(int);
+            info_hash_t stats_job(int64_t);
             info_hash_t stats_tube(std::string);
         protected:
             float timeout_secs;

--- a/benchmark.cc
+++ b/benchmark.cc
@@ -17,7 +17,7 @@ double duration(timeval *start, timeval *end) {
     return (double)((end->tv_sec * 1000000 + end->tv_usec) - (start->tv_sec * 1000000 + start->tv_usec)) / 1000000.0;
 }
 
-void* producer(void *arg) {
+void* producer(void* /*arg*/) {
     Client client("127.0.0.1", 11300);
 
     timeval start, end;
@@ -34,7 +34,7 @@ void* producer(void *arg) {
     return 0;
 }
 
-void* consumer(void *arg) {
+void* consumer(void* /*arg*/) {
     Client client("127.0.0.1", 11300);
 
     Job job;

--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -1,11 +1,13 @@
 #include "beanstalk.h"
 #include <stdio.h>
 #include <assert.h>
+#include <inttypes.h>
 
 int main() {
     BSJ *job;
     char *yaml;
-    int id, socket = bs_connect("127.0.0.1", 11300);
+    int64_t id;
+    int socket = bs_connect("127.0.0.1", 11300);
 
     assert(socket != BS_STATUS_FAIL);
     assert(bs_use(socket,    "test")    == BS_STATUS_OK);
@@ -14,23 +16,23 @@ int main() {
 
     id = bs_put(socket, 0, 0, 60, "hello world", 11);
     assert(id > 0);
-    printf("put job id: %d\n", id);
+    printf("put job id: %"PRId64"\n", id);
 
     assert(bs_reserve_with_timeout(socket, 2, &job) == BS_STATUS_OK);
     assert(job);
 
-    printf("reserve job id: %d size: %lu\n", job->id, job->size);
+    printf("reserve job id: %"PRId64" size: %lu\n", job->id, job->size);
     write(fileno(stderr), job->data, job->size);
     write(fileno(stderr), "\r\n", 2);
 
-    printf("release job id: %d\n", job->id);
+    printf("release job id: %"PRId64"\n", job->id);
     assert(bs_release(socket, job->id, 0, 0) == BS_STATUS_OK);
 
     bs_free_job(job);
     assert(bs_peek_ready(socket, &job) == BS_STATUS_OK);
-    printf("peek job id: %d\n", job->id);
+    printf("peek job id: %"PRId64"\n", job->id);
 
-    printf("delete job id: %d\n", job->id);
+    printf("delete job id: %"PRId64"\n", job->id);
     assert(bs_delete(socket, job->id) == BS_STATUS_OK);
     bs_free_job(job);
 

--- a/examples/c/example2.c
+++ b/examples/c/example2.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <sys/select.h>
 #include <fcntl.h>
+#include <inttypes.h>
 
 // example 2: polling the socket descriptor
 
@@ -21,7 +22,8 @@ int select_poll(int rw, int fd) {
 
 int main() {
     BSJ *job;
-    int id, handle = bs_connect("127.0.0.1", 11300);
+    int64_t id;
+    int handle = bs_connect("127.0.0.1", 11300);
 
     assert(handle != BS_STATUS_FAIL);
     assert(bs_use(handle,    "test")    == BS_STATUS_OK);
@@ -30,7 +32,7 @@ int main() {
 
     id = bs_put(handle, 0, 0, 60, "hello world", 11);
     assert(id > 0);
-    printf("put job id: %d\n", id);
+    printf("put job id: %"PRId64"\n", id);
 
     // poll read & writes from now on.
     bs_start_polling(select_poll);
@@ -39,13 +41,13 @@ int main() {
     assert(bs_reserve_with_timeout(handle, 2, &job) == BS_STATUS_OK);
     assert(job);
 
-    printf("reserve job id: %d size: %lu\n", job->id, job->size);
+    printf("reserve job id: %"PRId64" size: %lu\n", job->id, job->size);
     write(fileno(stderr), job->data, job->size);
     write(fileno(stderr), "\r\n", 2);
 
     bs_reset_polling();
     fcntl(handle, F_SETFL, fcntl(handle, F_GETFL) ^ O_NONBLOCK);
-    printf("delete job id: %d\n", job->id);
+    printf("delete job id: %"PRId64"\n", job->id);
     assert(bs_delete(handle, job->id) == BS_STATUS_OK);
     bs_free_job(job);
     bs_disconnect(handle);

--- a/examples/cpp/example1.cc
+++ b/examples/cpp/example1.cc
@@ -12,7 +12,7 @@ int main() {
     assert(client.watch("test"));
     assert(client.ignore("default"));
 
-    int id = client.put("hello");
+    int64_t id = client.put("hello");
     assert(id > 0);
     cout << "put job id: " << id << endl;
 

--- a/test/test1.cc
+++ b/test/test1.cc
@@ -34,7 +34,7 @@ void setup() {
     // setup message
     for (i = 0; i < lines; i++) {
         for (j = 0; j < 26; j++)
-            large_message[n++] = j + 97;
+          large_message[n++] = (char)(j + 97);
         large_message[n++] = '\n';
     }
 }


### PR DESCRIPTION
Job ids can be bigger than a 32 bit int which is supported in this change.
Delay, Priority and TTR have been changed to unsigned ints.
I've also changed some places where a size_t was returned instead of an ssize_t swallowing errors.
I know this is a major API change but for us supporting job swith a higher id is a must.
Let me know if you think it's worthwhile to include this change in the client library!
Cheers,
